### PR TITLE
Using redis library v2.6 instead of 0.12, fixed bugs in connection logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A redis plugin for cache-service.",
   "main": "redisCacheModule.js",
   "dependencies": {
-    "redis": "0.12.1"
+    "redis": "^2.6.2"
   },
   "devDependencies": {
     "mocha": "2.2.4",

--- a/redisCacheModule.js
+++ b/redisCacheModule.js
@@ -372,3 +372,4 @@ function redisCacheModule(config){
 }
 
 module.exports = redisCacheModule;
+redisCacheModule._retryStrategy = retryStrategy;

--- a/test/server/redis-cache-module.js
+++ b/test/server/redis-cache-module.js
@@ -155,4 +155,19 @@ describe('redisCacheModule Tests', function () {
     }, 1500);
   });
 
+  it('should retry connecting when retries is less than 5 times', function() {
+    var mockOptions = {
+      attempt: 5,
+      total_retry_time: 1000,
+      times_connected: 0 };
+    expect(rcModule._retryStrategy(mockOptions)).toExist()
+  });
+
+  it('should retry connecting when retries is more than 5 times', function() {
+    var mockOptions = {
+      attempt: 6,
+      total_retry_time: 1000,
+      times_connected: 0 };
+    expect(rcModule._retryStrategy(mockOptions)).toNotExist()
+  });
 });


### PR DESCRIPTION
This is both a bugfix and a redis library upgrade.

I was trying to set up a few independent instances of my app and I was wondering why the other redis-using code in my app was working fine when I set the database number in the path, but cache-service-redis was still trying to access database zero.

Redis 0.12 doesn't support database numbers, as it turns out.  It's an old release at this point.  So I decided to upgrade to the latest version of the Redis library, which lets you pass the Redis URL to the constructor directly, which has the nice effect of letting me remove the URL parsing in the cache service.  This fixes the bug I'm experiencing while trying to install my app, which depends on cache-service-redis, in production.

I also fixed the deprecation warnings.