### PR TITLE
Fix warning messages from Redis regarding Auth information

### DIFF
--- a/redisCacheModule.js
+++ b/redisCacheModule.js
@@ -348,7 +348,11 @@ function redisCacheModule(config){
             self.db = redis.createClient(self.redisData.port,
               self.redisData.hostname, {'no_ready_check': true, 
               retry_strategy: retryStrategy});
-            self.db.auth(self.redisData.auth);
+            
+            // don't call redis auth method if no auth info passed
+            if (self.redisData.auth != null) {
+              self.db.auth(self.redisData.auth);
+            }
           }
           self.db.on('error', function(err) {
             console.log('Error ' + err);


### PR DESCRIPTION
Proposing this fix to issue https://github.com/jpodwys/cache-service-redis/issues/11 where Redis now emits warning messages when setting empty auth information.