### PR TITLE
pass JSON object to redisCacheModule

### DIFF
--- a/redisCacheModule.js
+++ b/redisCacheModule.js
@@ -36,7 +36,9 @@ function redisCacheModule(config){
   self.backgroundRefreshIntervalCheck = (typeof config.backgroundRefreshIntervalCheck === 'boolean') ? config.backgroundRefreshIntervalCheck : true;
   self.backgroundRefreshInterval = config.backgroundRefreshInterval || 60000;
   self.backgroundRefreshMinTtl = config.backgroundRefreshMinTtl || 70000;
+  self.JSON = config.JSON || Object.create(JSON);
   self.logJsonParseFailures = config.logJsonParseFailures || false;
+
   var refreshKeys = {};
   var backgroundRefreshEnabled = false;
 
@@ -134,7 +136,7 @@ function redisCacheModule(config){
       log(false, 'Attempting to get key:', {key: cacheKey});
       self.db.get(cacheKey, function(err, result){
         try {
-          result = JSON.parse(result);
+          result = self.JSON.parse(result);
         } catch (err) {
           if(self.logJsonParseFailures) {
             log(true, 'Error parsing JSON, err:', err);
@@ -163,7 +165,7 @@ function redisCacheModule(config){
       for(var i = 0; i < response.length; i++){
         if(response[i] !== null){
           try {
-            response[i] = JSON.parse(response[i]);
+            response[i] = self.JSON.parse(response[i]);
           } catch (err) {
             if(self.logJsonParseFailures) {
               log(true, 'Error parsing JSON, err:', err);
@@ -201,7 +203,7 @@ function redisCacheModule(config){
         var exp = (expiration * 1000) + Date.now();
         if(typeof value === 'object'){
           try {
-            value = JSON.stringify(value);
+            value = self.JSON.stringify(value);
           } catch (err) {
             if(self.logJsonParseFailures) {
               log(true, 'Error converting to JSON, err:', err);
@@ -252,7 +254,7 @@ function redisCacheModule(config){
           value = value.cacheValue;
         }
         try {
-          value = JSON.stringify(value);
+          value = self.JSON.stringify(value);
         } catch (err) {
           if(self.logJsonParseFailures) {
             log(true, 'Error converting to JSON, err:', err);
@@ -342,13 +344,13 @@ function redisCacheModule(config){
         if (self.redisData) {
           if(typeof self.redisData === 'string'){
             self.db = redis.createClient(self.redisData,
-              {'no_ready_check': true, 
+              {'no_ready_check': true,
               retry_strategy: retryStrategy});
           } else {
             self.db = redis.createClient(self.redisData.port,
-              self.redisData.hostname, {'no_ready_check': true, 
+              self.redisData.hostname, {'no_ready_check': true,
               retry_strategy: retryStrategy});
-            
+
             // don't call redis auth method if no auth info passed
             if (self.redisData.auth) {
               self.db.auth(self.redisData.auth);

--- a/test/server/redis-cache-module.js
+++ b/test/server/redis-cache-module.js
@@ -154,7 +154,26 @@ describe('redisCacheModule Tests', function () {
 
     }, 1500);
   });
+  it('Using custom JSON interface should parse JSON to custom object', function (done) {
+    this.timeout(5000);
 
+    redisCache.logJsonParseFailures = true;
+    redisCache.JSON.parse = function (text) {
+      const obj = JSON.parse(text);
+      if (obj.type === 'Buffer') {
+        return Buffer.from(obj);
+      } else {
+        return obj;
+      }
+    };
+
+    const buffer = Buffer.from([0x00, 0x61, 0x00, 0x62, 0x00, 0x63])
+    redisCache.set('bffr', buffer);
+    redisCache.get('bffr', function (err, response) {
+      expect(response).toEqual(buffer);
+      done();
+    });
+  });
   it('should retry connecting when retries is less than 5 times', function() {
     var mockOptions = {
       attempt: 5,


### PR DESCRIPTION
When caching response containing a data property of type Buffer, the `JSON.stringify` method will wrap the data property with `{type: 'Buffer', data}` (See [node](https://nodejs.org/api/buffer.html#buffer_buf_tojson)).

The get from cache module will then parse it back to an generic object instead of a Buffer.

This fix allows the cache user to use a custom parser instead.



