### PR TITLE
pass JSON object to redisCacheModule (re-merge)

### DIFF
--- a/redisCacheModule.js
+++ b/redisCacheModule.js
@@ -36,6 +36,7 @@ function redisCacheModule(config){
   self.backgroundRefreshIntervalCheck = (typeof config.backgroundRefreshIntervalCheck === 'boolean') ? config.backgroundRefreshIntervalCheck : true;
   self.backgroundRefreshInterval = config.backgroundRefreshInterval || 60000;
   self.backgroundRefreshMinTtl = config.backgroundRefreshMinTtl || 70000;
+  self.JSON = config.JSON || Object.create(JSON);
   self.logJsonParseFailures = config.logJsonParseFailures || false;
   self.nameSpace = config.nameSpace || '';
 
@@ -145,7 +146,7 @@ function redisCacheModule(config){
       key = prefixKey(key);
       self.db.get(key, function(err, result){
         try {
-          result = JSON.parse(result);
+          result = self.JSON.parse(result);
         } catch (err) {
           if(self.logJsonParseFailures) {
             log(true, 'Error parsing JSON, err:', err);
@@ -175,7 +176,7 @@ function redisCacheModule(config){
       for(var i = 0; i < response.length; i++){
         if(response[i] !== null){
           try {
-            response[i] = JSON.parse(response[i]);
+            response[i] = self.JSON.parse(response[i]);
           } catch (err) {
             if(self.logJsonParseFailures) {
               log(true, 'Error parsing JSON, err:', err);
@@ -212,7 +213,7 @@ function redisCacheModule(config){
         var exp = (expiration * 1000) + Date.now();
         if(typeof value === 'object'){
           try {
-            value = JSON.stringify(value);
+            value = self.JSON.stringify(value);
           } catch (err) {
             if(self.logJsonParseFailures) {
               log(true, 'Error converting to JSON, err:', err);
@@ -264,7 +265,7 @@ function redisCacheModule(config){
           value = value.cacheValue;
         }
         try {
-          value = JSON.stringify(value);
+          value = self.JSON.stringify(value);
         } catch (err) {
           if(self.logJsonParseFailures) {
             log(true, 'Error converting to JSON, err:', err);

--- a/test/server/redis-cache-module.js
+++ b/test/server/redis-cache-module.js
@@ -171,7 +171,26 @@ describe('redisCacheModule Tests', function () {
 
     }, 1500);
   });
+  it('Using custom JSON interface should parse JSON to custom object', function (done) {
+    this.timeout(5000);
 
+    redisCache.logJsonParseFailures = true;
+    redisCache.JSON.parse = function (text) {
+      const obj = JSON.parse(text);
+      if (obj.type === 'Buffer') {
+        return Buffer.from(obj);
+      } else {
+        return obj;
+      }
+    };
+
+    const buffer = Buffer.from([0x00, 0x61, 0x00, 0x62, 0x00, 0x63])
+    redisCache.set('bffr', buffer);
+    redisCache.get('bffr', function (err, response) {
+      expect(response).toEqual(buffer);
+      done();
+    });
+  });
   it('should retry connecting when retries is less than 5 times', function() {
     var mockOptions = {
       attempt: 5,


### PR DESCRIPTION
[Original PR](https://github.com/jpodwys/cache-service-redis/pull/13) was obliterated by sequent [PR](https://github.com/jpodwys/cache-service-redis/pull/14)'s `git revert`. My bad.